### PR TITLE
tests: added essential service layer unit tests

### DIFF
--- a/internal/service/mark_service_test.go
+++ b/internal/service/mark_service_test.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mikkkkkkka/what-i-know-api/internal/domain"
+)
+
+type markRepoStub struct {
+	created *domain.Mark
+	gotNote *domain.Mark
+}
+
+func (s *markRepoStub) GetByID(_ context.Context, _ string) (*domain.Mark, error) {
+	if s.gotNote == nil {
+		return nil, errors.New("mark not found in stub")
+	}
+
+	return s.gotNote, nil
+}
+
+func (s *markRepoStub) GetByUserID(_ context.Context, _ string) ([]*domain.Mark, error) {
+	return nil, nil
+}
+
+func (s *markRepoStub) Create(_ context.Context, mark *domain.Mark) error {
+	s.created = mark
+	return nil
+}
+
+func (s *markRepoStub) Update(_ context.Context, mark *domain.Mark) error {
+	s.created = mark
+	return nil
+}
+
+func (s *markRepoStub) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestMarkServiceCreateMarkRejectsInvalidInput(t *testing.T) {
+	repo := &markRepoStub{}
+	svc := NewMarkService(repo)
+
+	err := svc.CreateMark(context.Background(), CreateMarkRequest{
+		ID:      "mark-id",
+		UserID:  " ",
+		Date:    time.Now(),
+		Content: "content",
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("expected repository create not to be called")
+	}
+}
+
+func TestMarkServiceCreateMarkNormalizesStrings(t *testing.T) {
+	repo := &markRepoStub{}
+	svc := NewMarkService(repo)
+
+	err := svc.CreateMark(context.Background(), CreateMarkRequest{
+		ID:      " mark-id ",
+		UserID:  " user-id ",
+		Date:    time.Date(2026, 4, 2, 12, 0, 0, 0, time.FixedZone("UTC+3", 3*60*60)),
+		Content: "  content  ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.created == nil {
+		t.Fatal("expected repository create to be called")
+	}
+	if repo.created.ID != "mark-id" || repo.created.UserID != "user-id" || repo.created.Content != "content" {
+		t.Fatalf("unexpected normalized mark: %+v", repo.created)
+	}
+	if repo.created.Date.Location() != time.UTC {
+		t.Fatalf("expected UTC date, got %v", repo.created.Date.Location())
+	}
+}
+
+func TestMarkServiceUpdateMarkRejectsWhitespaceOnlyContent(t *testing.T) {
+	repo := &markRepoStub{
+		gotNote: &domain.Mark{ID: "mark-id", Content: "old"},
+	}
+	svc := NewMarkService(repo)
+
+	err := svc.UpdateMark(context.Background(), UpdateMarkRequest{
+		ID:      " mark-id ",
+		Content: " ",
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("expected repository update not to be called")
+	}
+}

--- a/internal/service/note_service_test.go
+++ b/internal/service/note_service_test.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mikkkkkkka/what-i-know-api/internal/domain"
+)
+
+type noteRepoStub struct {
+	created *domain.Note
+	gotID   string
+	gotNote *domain.Note
+}
+
+func (s *noteRepoStub) GetByID(_ context.Context, id string) (*domain.Note, error) {
+	s.gotID = id
+	if s.gotNote == nil {
+		return nil, errors.New("note not found in stub")
+	}
+
+	return s.gotNote, nil
+}
+
+func (s *noteRepoStub) GetByUserID(_ context.Context, _ string) ([]*domain.Note, error) {
+	return nil, nil
+}
+
+func (s *noteRepoStub) Create(_ context.Context, note *domain.Note) error {
+	s.created = note
+	return nil
+}
+
+func (s *noteRepoStub) Update(_ context.Context, note *domain.Note) error {
+	s.created = note
+	return nil
+}
+
+func (s *noteRepoStub) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestNoteServiceCreateNoteRejectsInvalidInput(t *testing.T) {
+	repo := &noteRepoStub{}
+	svc := NewNoteService(repo)
+
+	err := svc.CreateNote(context.Background(), CreateNoteRequest{
+		ID:      " ",
+		UserID:  "user",
+		Title:   "title",
+		Content: "content",
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("expected repository create not to be called")
+	}
+}
+
+func TestNoteServiceCreateNoteNormalizesStrings(t *testing.T) {
+	repo := &noteRepoStub{}
+	svc := NewNoteService(repo)
+
+	err := svc.CreateNote(context.Background(), CreateNoteRequest{
+		ID:      " note-id ",
+		UserID:  " user-id ",
+		Title:   " title ",
+		Content: "  content  ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.created == nil {
+		t.Fatal("expected repository create to be called")
+	}
+	if repo.created.ID != "note-id" || repo.created.UserID != "user-id" || repo.created.Title != "title" || repo.created.Content != "content" {
+		t.Fatalf("unexpected normalized note: %+v", repo.created)
+	}
+}
+
+func TestNoteServiceUpdateNoteRejectsWhitespaceOnlyFields(t *testing.T) {
+	repo := &noteRepoStub{
+		gotNote: &domain.Note{ID: "note-id", Title: "old", Content: "old"},
+	}
+	svc := NewNoteService(repo)
+
+	err := svc.UpdateNote(context.Background(), UpdateNoteRequest{
+		ID:      " note-id ",
+		Title:   " ",
+		Content: "content",
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("expected repository update not to be called")
+	}
+}

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/mikkkkkkka/what-i-know-api/internal/domain"
+)
+
+type userRepoStub struct {
+	created *domain.User
+	gotUser *domain.User
+}
+
+func (s *userRepoStub) GetByID(_ context.Context, _ string) (*domain.User, error) {
+	if s.gotUser == nil {
+		return nil, errors.New("user not found in stub")
+	}
+
+	return s.gotUser, nil
+}
+
+func (s *userRepoStub) GetByUsername(_ context.Context, _ string) (*domain.User, error) {
+	return nil, nil
+}
+
+func (s *userRepoStub) Create(_ context.Context, user *domain.User) error {
+	s.created = user
+	return nil
+}
+
+func (s *userRepoStub) Update(_ context.Context, user *domain.User) error {
+	s.created = user
+	return nil
+}
+
+func (s *userRepoStub) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+type idGeneratorStub struct {
+	id string
+}
+
+func (s idGeneratorStub) Generate() (string, error) {
+	return s.id, nil
+}
+
+type passwordHasherStub struct {
+	hashed       string
+	lastPassword string
+}
+
+func (s *passwordHasherStub) Hash(password string) (string, error) {
+	s.lastPassword = password
+	return s.hashed, nil
+}
+
+func (s *passwordHasherStub) Compare(_, _ string) error {
+	return nil
+}
+
+func TestUserServiceCreateUserRejectsInvalidInput(t *testing.T) {
+	repo := &userRepoStub{}
+	hasher := &passwordHasherStub{hashed: "hashed"}
+	svc := NewUserService(repo, idGeneratorStub{id: "user-id"}, hasher)
+
+	_, err := svc.CreateUser(context.Background(), CreateUserRequest{
+		Username: " ",
+		Password: "secret",
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("expected repository create not to be called")
+	}
+	if hasher.lastPassword != "" {
+		t.Fatal("expected password hashing not to be called")
+	}
+}
+
+func TestUserServiceCreateUserNormalizesUsernameAndPassword(t *testing.T) {
+	repo := &userRepoStub{}
+	hasher := &passwordHasherStub{hashed: "hashed"}
+	svc := NewUserService(repo, idGeneratorStub{id: "user-id"}, hasher)
+
+	id, err := svc.CreateUser(context.Background(), CreateUserRequest{
+		Username: " user ",
+		Password: " secret ",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "user-id" {
+		t.Fatalf("expected generated id, got %q", id)
+	}
+	if hasher.lastPassword != "secret" {
+		t.Fatalf("expected original password to be hashed, got %q", hasher.lastPassword)
+	}
+	if repo.created == nil {
+		t.Fatal("expected repository create to be called")
+	}
+	if repo.created.Username != "user" {
+		t.Fatalf("expected normalized username, got %q", repo.created.Username)
+	}
+}
+
+func TestUserServiceUpdateUserRejectsWhitespaceOnlyUsername(t *testing.T) {
+	repo := &userRepoStub{
+		gotUser: &domain.User{ID: "user-id", Username: "old"},
+	}
+	svc := NewUserService(repo, idGeneratorStub{id: "user-id"}, &passwordHasherStub{hashed: "hashed"})
+
+	err := svc.UpdateUser(context.Background(), UpdateUserRequest{
+		ID:       " user-id ",
+		Username: " ",
+	})
+	if !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("expected ErrInvalidInput, got %v", err)
+	}
+	if repo.created != nil {
+		t.Fatal("expected repository update not to be called")
+	}
+}


### PR DESCRIPTION
*GENERATED WITH COPILOT*

This pull request adds comprehensive unit tests for the service layer, specifically for `NoteService`, `MarkService`, and `UserService`. The new tests validate input handling, normalization of fields, and ensure that invalid input does not trigger repository or password hasher actions. These tests use stub implementations of repositories and dependencies to isolate service logic.

**New Service Layer Unit Tests:**

*NoteService tests (`internal/service/note_service_test.go`):*
- Added tests to verify that invalid input is rejected, string fields are normalized, and whitespace-only updates are not accepted.

*MarkService tests (`internal/service/mark_service_test.go`):*
- Added tests to ensure invalid input is rejected, string fields and date are normalized (including conversion to UTC), and whitespace-only content is not accepted on update.

*UserService tests (`internal/service/user_service_test.go`):*
- Added tests to check for proper rejection of invalid input, normalization of username and password, and prevention of repository or hasher calls on invalid input.